### PR TITLE
overlay: mux everything quic

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - "1113:1113/tcp"
     volumes:
       - ./certs:/certs:ro
-    command: --verbose server --cert-dir /certs --chord seed:1111 --gateway seed:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com}
+    command: --verbose server --cert-dir /certs --listen seed:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com}
 
   srva:
     image: specter
@@ -34,7 +34,7 @@ services:
       - "2113:1113/tcp"
     volumes:
       - ./certs:/certs:ro
-    command: --verbose server --cert-dir /certs --chord srva:1111 --gateway srva:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1111
+    command: --verbose server --cert-dir /certs --listen srva:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1113
 
   srvb:
     image: specter
@@ -44,7 +44,7 @@ services:
       - "3113:1113/tcp"
     volumes:
       - ./certs:/certs:ro
-    command: --verbose server --cert-dir /certs --chord srvb:1111 --gateway srvb:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1111
+    command: --verbose server --cert-dir /certs --listen srvb:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1113
 
   # srvc:
   #   image: specter
@@ -54,7 +54,7 @@ services:
   #     - "4113:1113/tcp"
   #   volumes:
   #     - ./certs:/certs:ro
-  #   command: --verbose server --cert-dir /certs --chord srvc:1111 --gateway srvc:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1111
+  #   command: --verbose server --cert-dir /certs --listen srvc:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1113
 
   # srvd:
   #   image: specter
@@ -64,4 +64,4 @@ services:
   #     - "5113:1113/tcp"
   #   volumes:
   #     - ./certs:/certs:ro
-  #   command: --verbose server --cert-dir /certs --chord srvd:1111 --gateway srvd:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1111
+  #   command: --verbose server --cert-dir /certs --listen srvd:1113 --apex dev.con.nect.sh ${SKIP:---challenger acme://admin@example.com:cf_token@hostedacme.com} --join seed:1113

--- a/overlay/alpn_mux.go
+++ b/overlay/alpn_mux.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"kon.nect.sh/specter/spec/acceptor"
-	"kon.nect.sh/specter/spec/cipher"
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/zhangyunhao116/skipmap"
@@ -16,20 +15,23 @@ import (
 
 type ALPNMux struct {
 	logger   *zap.Logger
-	baseCfg  *tls.Config
 	listener quic.EarlyListener
-	mux      *skipmap.StringMap[*acceptor.HTTP3Acceptor]
+	mux      *skipmap.StringMap[*protoCfg]
 }
 
-func NewMux(logger *zap.Logger, addr string, provider cipher.CertProviderFunc) (*ALPNMux, error) {
-	a := &ALPNMux{
-		logger:  logger,
-		mux:     skipmap.NewString[*acceptor.HTTP3Acceptor](),
-		baseCfg: cipher.GetGatewayTLSConfig(provider, nil),
-	}
-	a.baseCfg.GetConfigForClient = a.getConfigForClient
+type protoCfg struct {
+	acceptor *acceptor.HTTP3Acceptor
+	tls      *tls.Config
+}
 
-	listener, err := quic.ListenAddrEarly(addr, a.baseCfg, quicConfig)
+func NewMux(logger *zap.Logger, addr string) (*ALPNMux, error) {
+	a := &ALPNMux{
+		logger: logger,
+		mux:    skipmap.NewString[*protoCfg](),
+	}
+	listener, err := quic.ListenAddrEarly(addr, &tls.Config{
+		GetConfigForClient: a.getConfigForClient,
+	}, quicConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -38,37 +40,43 @@ func NewMux(logger *zap.Logger, addr string, provider cipher.CertProviderFunc) (
 }
 
 func (a *ALPNMux) getConfigForClient(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+	var baseCfg *tls.Config
 	var xCfg *tls.Config
 	var found bool
 
-	a.mux.Range(func(proto string, _ *acceptor.HTTP3Acceptor) bool {
+	a.mux.Range(func(proto string, cfg *protoCfg) bool {
 		for _, cP := range hello.SupportedProtos {
 			if proto == cP {
 				found = true
+				baseCfg = cfg.tls
 				return false
 			}
 		}
 		return true
 	})
+
 	if found {
-		xCfg = a.baseCfg.Clone()
+		xCfg = baseCfg.Clone()
 		xCfg.NextProtos = hello.SupportedProtos
 		return xCfg, nil
 	}
 	return nil, errors.New("cipher: no mutually supported protocols")
 }
 
-func (a *ALPNMux) For(protos ...string) quic.EarlyListener {
-	l := acceptor.NewH3Acceptor(a.listener)
-	for _, proto := range protos {
-		a.mux.Store(proto, l)
+func (a *ALPNMux) With(baseCfg *tls.Config, protos ...string) quic.EarlyListener {
+	cfg := &protoCfg{
+		acceptor: acceptor.NewH3Acceptor(a.listener),
+		tls:      baseCfg,
 	}
-	return l
+	for _, proto := range protos {
+		a.mux.Store(proto, cfg)
+	}
+	return cfg.acceptor
 }
 
-func (a *ALPNMux) Aceept(ctx context.Context) {
+func (a *ALPNMux) Accept(ctx context.Context) {
 	protos := make([]string, 0)
-	a.mux.Range(func(proto string, _ *acceptor.HTTP3Acceptor) bool {
+	a.mux.Range(func(proto string, _ *protoCfg) bool {
 		protos = append(protos, proto)
 		return true
 	})
@@ -83,8 +91,8 @@ func (a *ALPNMux) Aceept(ctx context.Context) {
 }
 
 func (a *ALPNMux) Close() {
-	a.mux.Range(func(_ string, acceptor *acceptor.HTTP3Acceptor) bool {
-		acceptor.Close()
+	a.mux.Range(func(_ string, cfg *protoCfg) bool {
+		cfg.acceptor.Close()
 		return true
 	})
 	a.listener.Close()
@@ -94,18 +102,20 @@ func (a *ALPNMux) handleConnection(ctx context.Context, conn quic.EarlyConnectio
 	hsCtx := conn.HandshakeComplete()
 	select {
 	case <-time.After(quicConfig.HandshakeIdleTimeout):
+		conn.CloseWithError(401, "Gone")
 		return
 	case <-ctx.Done():
+		conn.CloseWithError(401, "Gone")
 		return
 	case <-hsCtx.Done():
 	}
 
 	cs := conn.ConnectionState().TLS
 
-	acceptor, ok := a.mux.Load(cs.NegotiatedProtocol)
+	cfg, ok := a.mux.Load(cs.NegotiatedProtocol)
 	if !ok {
 		conn.CloseWithError(404, "Unsupported protocol")
 		return
 	}
-	acceptor.Conn <- conn
+	cfg.acceptor.Conn <- conn
 }

--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -16,7 +16,7 @@ import (
 
 type nodeConnection struct {
 	peer *protocol.Node
-	quic quic.Connection
+	quic quic.EarlyConnection
 }
 
 type TransportConfig struct {


### PR DESCRIPTION
This commit moves the chord listener into ALPNMux as well, allowing specter to only require a single port