### PR TITLE
tun: upgrade to http2 when proxying to client

### DIFF
--- a/tun/client/client.go
+++ b/tun/client/client.go
@@ -18,6 +18,8 @@ import (
 	"kon.nect.sh/specter/spec/tun"
 
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 // Tunnel create procedure:
@@ -133,8 +135,9 @@ func (c *Client) Tunnel(ctx context.Context, hostname string) {
 	accepter := &acceptor.HTTP2Acceptor{
 		Conn: httpCh,
 	}
+	h2s := &http2.Server{}
 	forwarder := &http.Server{
-		Handler:  proxy,
+		Handler:  h2c.NewHandler(proxy, h2s),
 		ErrorLog: zap.NewStdLog(c.logger),
 	}
 	go func() {

--- a/tun/gateway/gateway.go
+++ b/tun/gateway/gateway.go
@@ -100,6 +100,13 @@ func (g *Gateway) Start(ctx context.Context) {
 	go g.acceptHTTP3(ctx)
 }
 
+func (g *Gateway) Close() {
+	g.h3ApexServer.Close()
+	g.h3TunnelServer.Close()
+	g.http2ApexAcceptor.Close()
+	g.http2TunnelAcceptor.Close()
+}
+
 func (g *Gateway) acceptHTTP2(ctx context.Context) {
 	for {
 		conn, err := g.H2Listener.Accept()


### PR DESCRIPTION
By using `http2.Transport` in `httputil.ReverseProxy` and `h2c.NewHandler` in the client side, we can reuse the same quic stream for multiple requests back to the client.