### PR TITLE
tun/client: self healing tunnels

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -34,6 +34,30 @@ jobs:
             ${{ runner.os }}-go-
       - name: Test with Coverage and Race Detector
         run: go test -v -short -race -timeout 120s ./...
+  integration:
+    name: Run Integration Tests
+    runs-on: 'ubuntu-latest'
+    env:
+      GO_RUN_INTEGRATION: "1"
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.19"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Generate Certificates
+        run: make certs
+      - name: Test with Integrations and Race Detector
+        run: go test -v -short -race -timeout 120s ./...
   coverage:
     name: Update Code Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -32,6 +32,30 @@ jobs:
             ${{ runner.os }}-go-
       - name: Test with Coverage and Race Detector
         run: go test -v -short -race -timeout 120s ./...
+  integration:
+    name: Run Integration Tests
+    runs-on: 'ubuntu-latest'
+    env:
+      GO_RUN_INTEGRATION: "1"
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.19"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Generate Certificates
+        run: make certs
+      - name: Test with Integrations and Race Detector
+        run: go test -v -short -race -timeout 120s ./...
   full:
     name: Run Full Test Suite
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=7 GOAMD64=v3 \
     go build -tags 'osusergo netgo urfave_cli_no_docs no_mocks' \
-    -ldflags "-s -w -extldflags -static -X=main.Build=`git rev-parse --short HEAD`" \
+    -ldflags "-s -w -extldflags -static -X=kon.nect.sh/specter/cmd/specter.Build=`git rev-parse --short HEAD`" \
     -o bin/specter .
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ COUNT=5
 GOARM=7
 GOAMD64=v3
 GOTAGS=-tags 'osusergo netgo urfave_cli_no_docs no_mocks'
-LDFLAGS=-ldflags "-s -w -extldflags -static -X=main.Build=$(BUILD)"
+LDFLAGS=-ldflags "-s -w -extldflags -static -X=kon.nect.sh/specter/cmd/specter.Build=$(BUILD)"
 TIMEOUT=180s
 
 plat_temp = $(subst /, ,$@)

--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -1,26 +1,7 @@
 package client
 
 import (
-	"crypto/tls"
-	"fmt"
-	"os"
-	"os/signal"
-	"strconv"
-	"strings"
-	"syscall"
-
-	"kon.nect.sh/specter/overlay"
-	"kon.nect.sh/specter/spec/protocol"
-	"kon.nect.sh/specter/spec/transport"
-	"kon.nect.sh/specter/spec/tun"
-	"kon.nect.sh/specter/tun/client"
-
 	"github.com/urfave/cli/v2"
-	"go.uber.org/zap"
-)
-
-var (
-	devApexOverride = ""
 )
 
 var Cmd = &cli.Command{
@@ -33,112 +14,21 @@ var Cmd = &cli.Command{
 			Value: false,
 			Usage: "disable TLS verification, useful for debugging and local development",
 		},
-		&cli.StringFlag{
-			Name:     "config",
-			Aliases:  []string{"c"},
-			Usage:    "path to config yaml file.",
-			Required: true,
+	},
+	Subcommands: []*cli.Command{
+		{
+			Name:      "tunnel",
+			ArgsUsage: " ",
+			Usage:     "create reverse highly available tunnels to this machine",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "config",
+					Aliases:  []string{"c"},
+					Usage:    "path to config yaml file.",
+					Required: true,
+				},
+			},
+			Action: cmdTunnel,
 		},
 	},
-	Action: cmdClient,
-}
-
-type parsedApex struct {
-	host string
-	port int
-}
-
-func (p *parsedApex) String() string {
-	return fmt.Sprintf("%s:%d", p.host, p.port)
-}
-
-func parseApex(apex string) (*parsedApex, error) {
-	port := 443
-	i := strings.Index(apex, ":")
-	if i != -1 {
-		nP, err := strconv.ParseInt(apex[i+1:], 0, 64)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing port number: %w", err)
-		}
-		apex = apex[:i]
-		port = int(nP)
-	}
-	return &parsedApex{
-		host: apex,
-		port: port,
-	}, nil
-}
-
-func createTransport(ctx *cli.Context, logger *zap.Logger, cfg *client.Config, apex *parsedApex) transport.Transport {
-	clientTLSConf := &tls.Config{
-		ServerName:         apex.host,
-		InsecureSkipVerify: ctx.Bool("insecure"),
-		NextProtos: []string{
-			tun.ALPN(protocol.Link_SPECTER_TUN),
-		},
-	}
-	if devApexOverride != "" {
-		clientTLSConf.ServerName = devApexOverride
-	}
-	return overlay.NewQUIC(overlay.TransportConfig{
-		Logger: logger,
-		Endpoint: &protocol.Node{
-			Id: cfg.ClientID,
-		},
-		ServerTLS: nil,
-		ClientTLS: clientTLSConf,
-	})
-}
-
-func cmdClient(ctx *cli.Context) error {
-	logger := ctx.App.Metadata["logger"].(*zap.Logger)
-
-	cfg, err := client.NewConfig(ctx.String("config"))
-	if err != nil {
-		return err
-	}
-
-	parsed, err := parseApex(cfg.Apex)
-	if err != nil {
-		return err
-	}
-
-	transport := createTransport(ctx, logger, cfg, parsed)
-	defer transport.Stop()
-
-	c, err := client.NewClient(ctx.Context, logger, transport, cfg)
-	if err != nil {
-		return err
-	}
-
-	if err := c.Register(ctx.Context); err != nil {
-		return err
-	}
-
-	nodes, err := c.RequestCandidates(ctx.Context)
-	if err != nil {
-		return err
-	}
-
-	connected := []*protocol.Node{}
-	for _, node := range nodes {
-		logger.Info("Connecting to specter server", zap.String("address", node.GetAddress()))
-		_, err := transport.DialDirect(ctx.Context, node)
-		if err != nil {
-			logger.Error("Failed to connect specter server", zap.String("address", node.GetAddress()), zap.Error(err))
-			continue
-		}
-		connected = append(connected, node)
-	}
-
-	c.SyncConfigTunnels(ctx.Context, connected)
-
-	go c.Accept(ctx.Context)
-
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-	logger.Info("received signal to stop", zap.String("signal", (<-sigs).String()))
-
-	return nil
 }

--- a/cmd/client/tunnel.go
+++ b/cmd/client/tunnel.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"kon.nect.sh/specter/overlay"
+	"kon.nect.sh/specter/spec/protocol"
+	"kon.nect.sh/specter/spec/tun"
+	"kon.nect.sh/specter/tun/client"
+
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+)
+
+var (
+	devApexOverride = ""
+)
+
+type parsedApex struct {
+	host string
+	port int
+}
+
+func (p *parsedApex) String() string {
+	return fmt.Sprintf("%s:%d", p.host, p.port)
+}
+
+func parseApex(apex string) (*parsedApex, error) {
+	port := 443
+	i := strings.Index(apex, ":")
+	if i != -1 {
+		nP, err := strconv.ParseInt(apex[i+1:], 0, 32)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing port number: %w", err)
+		}
+		apex = apex[:i]
+		port = int(nP)
+	}
+	return &parsedApex{
+		host: apex,
+		port: port,
+	}, nil
+}
+
+func createTransport(ctx *cli.Context, logger *zap.Logger, cfg *client.Config, apex *parsedApex) *overlay.QUIC {
+	clientTLSConf := &tls.Config{
+		ServerName:         apex.host,
+		InsecureSkipVerify: ctx.Bool("insecure"),
+		NextProtos: []string{
+			tun.ALPN(protocol.Link_SPECTER_TUN),
+		},
+	}
+	if devApexOverride != "" {
+		clientTLSConf.ServerName = devApexOverride
+	}
+	return overlay.NewQUIC(overlay.TransportConfig{
+		Logger: logger,
+		Endpoint: &protocol.Node{
+			Id: cfg.ClientID,
+		},
+		ClientTLS: clientTLSConf,
+	})
+}
+
+func cmdTunnel(ctx *cli.Context) error {
+	logger := ctx.App.Metadata["logger"].(*zap.Logger)
+
+	cfg, err := client.NewConfig(ctx.String("config"))
+	if err != nil {
+		return err
+	}
+
+	parsed, err := parseApex(cfg.Apex)
+	if err != nil {
+		return err
+	}
+
+	transport := createTransport(ctx, logger, cfg, parsed)
+	defer transport.Stop()
+
+	c, err := client.NewClient(ctx.Context, logger, transport, cfg)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if err := c.Register(ctx.Context); err != nil {
+		return err
+	}
+
+	if err := c.Initialize(ctx.Context); err != nil {
+		return err
+	}
+
+	go c.Accept(ctx.Context)
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	logger.Info("received signal to stop", zap.String("signal", (<-sigs).String()))
+
+	return nil
+}

--- a/cmd/specter/app.go
+++ b/cmd/specter/app.go
@@ -1,0 +1,62 @@
+package specter
+
+import (
+	"fmt"
+	"runtime"
+
+	"kon.nect.sh/specter/cmd/client"
+	"kon.nect.sh/specter/cmd/server"
+
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	Build = "head"
+)
+
+var (
+	App = cli.App{
+		Name:            "specter",
+		Usage:           fmt.Sprintf("build for %s on %s", runtime.GOARCH, runtime.GOOS),
+		Version:         Build,
+		HideHelpCommand: true,
+		Copyright:       "miragespace.com, licensed under MIT.",
+		Description:     "like ngrok, but ambitious and also with DHT for flavor",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "verbose",
+				Value: false,
+				Usage: "enable verbose logging",
+			},
+		},
+		Commands: []*cli.Command{
+			server.Cmd,
+			client.Cmd,
+		},
+		Before: ConfigLogger,
+	}
+)
+
+func ConfigLogger(ctx *cli.Context) error {
+	var config zap.Config
+	if ctx.Bool("verbose") {
+		config = zap.NewDevelopmentConfig()
+		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	} else {
+		config = zap.NewProductionConfig()
+	}
+	// Redirect everything to stderr
+	config.OutputPaths = []string{"stderr"}
+	logger, err := config.Build()
+	if err != nil {
+		return err
+	}
+	_, err = zap.RedirectStdLogAt(logger, zapcore.InfoLevel)
+	if err != nil {
+		return fmt.Errorf("redirecting stdlog output: %w", err)
+	}
+	ctx.App.Metadata["logger"] = logger
+	return nil
+}

--- a/compose-client.yaml
+++ b/compose-client.yaml
@@ -16,7 +16,7 @@ services:
       - specter
     volumes:
       - ./dev/client:/app/config
-    command: --verbose client --insecure --config /app/config/specter.yaml
+    command: --verbose client --insecure tunnel --config /app/config/specter.yaml
 
 networks:
   specter:

--- a/integrations/tunnel_test.go
+++ b/integrations/tunnel_test.go
@@ -1,0 +1,113 @@
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"kon.nect.sh/specter/cmd/client"
+	"kon.nect.sh/specter/cmd/server"
+	"kon.nect.sh/specter/cmd/specter"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	httpPort     = 49192
+	serverPort   = 21948
+	serverApex   = "dev.con.nect.sh"
+	yamlTemplate = `apex: %s:%d
+tunnels:
+  - target: http://127.0.0.1:%d
+`
+)
+
+func compileApp(cmd *cli.Command) *cli.App {
+	return &cli.App{
+		Name: "specter",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "verbose",
+				Value: false,
+				Usage: "enable verbose logging",
+			},
+		},
+		Commands: []*cli.Command{
+			cmd,
+		},
+		Before: specter.ConfigLogger,
+	}
+}
+
+func TestTunnel(t *testing.T) {
+	if os.Getenv("GO_RUN_INTEGRATION") == "" {
+		t.Skip("skipping integration tests")
+	}
+
+	as := require.New(t)
+
+	file, err := os.CreateTemp("", "client")
+	as.NoError(err)
+	defer os.Remove(file.Name())
+
+	_, err = file.WriteString(fmt.Sprintf(yamlTemplate, serverApex, serverPort, httpPort))
+	as.NoError(err)
+	as.NoError(file.Close())
+
+	serverArgs := []string{
+		"specter",
+		"--verbose",
+		"server",
+		"--cert-dir",
+		"../certs",
+		"--listen",
+		fmt.Sprintf("127.0.0.1:%d", serverPort),
+		"--apex",
+		serverApex,
+	}
+
+	clientArgs := []string{
+		"specter",
+		"--verbose",
+		"client",
+		"--insecure",
+		"tunnel",
+		"--config",
+		file.Name(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverReturn := make(chan struct{})
+	clientReturn := make(chan struct{})
+
+	go func() {
+		if err := compileApp(server.Cmd).RunContext(ctx, serverArgs); err != nil {
+			as.NoError(err)
+		}
+		close(serverReturn)
+	}()
+
+	select {
+	case <-serverReturn:
+		as.FailNow("server returned unexpectedly")
+	case <-time.After(time.Second * 3):
+	}
+
+	go func() {
+		if err := compileApp(client.Cmd).RunContext(ctx, clientArgs); err != nil {
+			as.NoError(err)
+		}
+		close(clientReturn)
+	}()
+
+	select {
+	case <-clientReturn:
+		as.FailNow("client returned unexpectedly")
+	case <-time.After(time.Second * 3):
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,66 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 
-	"kon.nect.sh/specter/cmd/client"
-	"kon.nect.sh/specter/cmd/server"
-
-	"github.com/urfave/cli/v2"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-)
-
-var (
-	Build = "head"
+	"kon.nect.sh/specter/cmd/specter"
 )
 
 func main() {
-	app := cli.App{
-		Name:            "specter",
-		Usage:           fmt.Sprintf("build for %s on %s", runtime.GOARCH, runtime.GOOS),
-		Version:         Build,
-		HideHelpCommand: true,
-		Copyright:       "miragespace.com, licensed under MIT.",
-		Description:     "like ngrok, but ambitious and also with DHT for flavor",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:  "verbose",
-				Value: false,
-				Usage: "enable verbose logging",
-			},
-		},
-		Commands: []*cli.Command{
-			server.Cmd,
-			client.Cmd,
-		},
-		Before: func(ctx *cli.Context) error {
-			var config zap.Config
-			if ctx.Bool("verbose") {
-				config = zap.NewDevelopmentConfig()
-				config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-			} else {
-				config = zap.NewProductionConfig()
-			}
-			// Redirect everything to stderr
-			config.OutputPaths = []string{"stderr"}
-			logger, err := config.Build()
-			if err != nil {
-				return err
-			}
-			_, err = zap.RedirectStdLogAt(logger, zapcore.InfoLevel)
-			if err != nil {
-				return fmt.Errorf("redirecting stdlog output: %w", err)
-			}
-			ctx.App.Metadata["logger"] = logger
-			return nil
-		},
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := specter.App.RunContext(ctx, os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
 }

--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -40,8 +40,5 @@ type QUIC struct {
 	directChan chan *transport.StreamDelegate
 	dgramChan  chan *transport.DatagramDelegate
 
-	estChan chan *protocol.Node
-	desChan chan *protocol.Node
-
 	TransportConfig
 }

--- a/spec/chord/chord.go
+++ b/spec/chord/chord.go
@@ -2,13 +2,8 @@ package chord
 
 import (
 	"math/rand"
-	"time"
 
 	"github.com/zeebo/xxh3"
-)
-
-var (
-	randy = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 const (
@@ -38,7 +33,7 @@ func Modulo(x, y uint64) uint64 {
 }
 
 func Random() uint64 {
-	return randy.Uint64() % mod
+	return rand.Uint64() % mod
 }
 
 func Between(low, target, high uint64, inclusive bool) bool {

--- a/spec/proto/tun.proto
+++ b/spec/proto/tun.proto
@@ -44,6 +44,13 @@ message ClientResponse {
     GetNodesResponse nodesResponse = 6;
     GenerateHostnameResponse hostnameResponse = 7;
     PublishTunnelResponse tunnelResponse = 8;
+
+    ClientPingResponse pingResponse = 15;
+}
+
+message ClientPingResponse {
+    Node node = 1;
+    string apex = 2;
 }
 
 message RegisterIdentityRequest {

--- a/spec/protocol/tun.pb.go
+++ b/spec/protocol/tun.pb.go
@@ -134,7 +134,7 @@ func (x Link_ALPN) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Link_ALPN.Descriptor instead.
 func (Link_ALPN) EnumDescriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{12, 0}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{13, 0}
 }
 
 type Tunnel struct {
@@ -351,6 +351,7 @@ type ClientResponse struct {
 	NodesResponse    *GetNodesResponse         `protobuf:"bytes,6,opt,name=nodesResponse,proto3" json:"nodesResponse,omitempty"`
 	HostnameResponse *GenerateHostnameResponse `protobuf:"bytes,7,opt,name=hostnameResponse,proto3" json:"hostnameResponse,omitempty"`
 	TunnelResponse   *PublishTunnelResponse    `protobuf:"bytes,8,opt,name=tunnelResponse,proto3" json:"tunnelResponse,omitempty"`
+	PingResponse     *ClientPingResponse       `protobuf:"bytes,15,opt,name=pingResponse,proto3" json:"pingResponse,omitempty"`
 }
 
 func (x *ClientResponse) Reset() {
@@ -413,6 +414,68 @@ func (x *ClientResponse) GetTunnelResponse() *PublishTunnelResponse {
 	return nil
 }
 
+func (x *ClientResponse) GetPingResponse() *ClientPingResponse {
+	if x != nil {
+		return x.PingResponse
+	}
+	return nil
+}
+
+type ClientPingResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Node *Node  `protobuf:"bytes,1,opt,name=node,proto3" json:"node,omitempty"`
+	Apex string `protobuf:"bytes,2,opt,name=apex,proto3" json:"apex,omitempty"`
+}
+
+func (x *ClientPingResponse) Reset() {
+	*x = ClientPingResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_spec_proto_tun_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ClientPingResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientPingResponse) ProtoMessage() {}
+
+func (x *ClientPingResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_spec_proto_tun_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientPingResponse.ProtoReflect.Descriptor instead.
+func (*ClientPingResponse) Descriptor() ([]byte, []int) {
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ClientPingResponse) GetNode() *Node {
+	if x != nil {
+		return x.Node
+	}
+	return nil
+}
+
+func (x *ClientPingResponse) GetApex() string {
+	if x != nil {
+		return x.Apex
+	}
+	return ""
+}
+
 type RegisterIdentityRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -424,7 +487,7 @@ type RegisterIdentityRequest struct {
 func (x *RegisterIdentityRequest) Reset() {
 	*x = RegisterIdentityRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[4]
+		mi := &file_spec_proto_tun_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -437,7 +500,7 @@ func (x *RegisterIdentityRequest) String() string {
 func (*RegisterIdentityRequest) ProtoMessage() {}
 
 func (x *RegisterIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[4]
+	mi := &file_spec_proto_tun_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -450,7 +513,7 @@ func (x *RegisterIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterIdentityRequest.ProtoReflect.Descriptor instead.
 func (*RegisterIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{4}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RegisterIdentityRequest) GetClient() *Node {
@@ -472,7 +535,7 @@ type RegisterIdentityResponse struct {
 func (x *RegisterIdentityResponse) Reset() {
 	*x = RegisterIdentityResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[5]
+		mi := &file_spec_proto_tun_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -485,7 +548,7 @@ func (x *RegisterIdentityResponse) String() string {
 func (*RegisterIdentityResponse) ProtoMessage() {}
 
 func (x *RegisterIdentityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[5]
+	mi := &file_spec_proto_tun_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -498,7 +561,7 @@ func (x *RegisterIdentityResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterIdentityResponse.ProtoReflect.Descriptor instead.
 func (*RegisterIdentityResponse) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{5}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RegisterIdentityResponse) GetToken() *ClientToken {
@@ -524,7 +587,7 @@ type GetNodesRequest struct {
 func (x *GetNodesRequest) Reset() {
 	*x = GetNodesRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[6]
+		mi := &file_spec_proto_tun_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -537,7 +600,7 @@ func (x *GetNodesRequest) String() string {
 func (*GetNodesRequest) ProtoMessage() {}
 
 func (x *GetNodesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[6]
+	mi := &file_spec_proto_tun_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -550,7 +613,7 @@ func (x *GetNodesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNodesRequest.ProtoReflect.Descriptor instead.
 func (*GetNodesRequest) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{6}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{7}
 }
 
 type GetNodesResponse struct {
@@ -564,7 +627,7 @@ type GetNodesResponse struct {
 func (x *GetNodesResponse) Reset() {
 	*x = GetNodesResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[7]
+		mi := &file_spec_proto_tun_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -577,7 +640,7 @@ func (x *GetNodesResponse) String() string {
 func (*GetNodesResponse) ProtoMessage() {}
 
 func (x *GetNodesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[7]
+	mi := &file_spec_proto_tun_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +653,7 @@ func (x *GetNodesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNodesResponse.ProtoReflect.Descriptor instead.
 func (*GetNodesResponse) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{7}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetNodesResponse) GetNodes() []*Node {
@@ -609,7 +672,7 @@ type GenerateHostnameRequest struct {
 func (x *GenerateHostnameRequest) Reset() {
 	*x = GenerateHostnameRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[8]
+		mi := &file_spec_proto_tun_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -622,7 +685,7 @@ func (x *GenerateHostnameRequest) String() string {
 func (*GenerateHostnameRequest) ProtoMessage() {}
 
 func (x *GenerateHostnameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[8]
+	mi := &file_spec_proto_tun_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -635,7 +698,7 @@ func (x *GenerateHostnameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateHostnameRequest.ProtoReflect.Descriptor instead.
 func (*GenerateHostnameRequest) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{8}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{9}
 }
 
 type GenerateHostnameResponse struct {
@@ -649,7 +712,7 @@ type GenerateHostnameResponse struct {
 func (x *GenerateHostnameResponse) Reset() {
 	*x = GenerateHostnameResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[9]
+		mi := &file_spec_proto_tun_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -662,7 +725,7 @@ func (x *GenerateHostnameResponse) String() string {
 func (*GenerateHostnameResponse) ProtoMessage() {}
 
 func (x *GenerateHostnameResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[9]
+	mi := &file_spec_proto_tun_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -675,7 +738,7 @@ func (x *GenerateHostnameResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateHostnameResponse.ProtoReflect.Descriptor instead.
 func (*GenerateHostnameResponse) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{9}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GenerateHostnameResponse) GetHostname() string {
@@ -698,7 +761,7 @@ type PublishTunnelRequest struct {
 func (x *PublishTunnelRequest) Reset() {
 	*x = PublishTunnelRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[10]
+		mi := &file_spec_proto_tun_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -711,7 +774,7 @@ func (x *PublishTunnelRequest) String() string {
 func (*PublishTunnelRequest) ProtoMessage() {}
 
 func (x *PublishTunnelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[10]
+	mi := &file_spec_proto_tun_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -724,7 +787,7 @@ func (x *PublishTunnelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishTunnelRequest.ProtoReflect.Descriptor instead.
 func (*PublishTunnelRequest) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{10}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *PublishTunnelRequest) GetHostname() string {
@@ -750,7 +813,7 @@ type PublishTunnelResponse struct {
 func (x *PublishTunnelResponse) Reset() {
 	*x = PublishTunnelResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[11]
+		mi := &file_spec_proto_tun_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -763,7 +826,7 @@ func (x *PublishTunnelResponse) String() string {
 func (*PublishTunnelResponse) ProtoMessage() {}
 
 func (x *PublishTunnelResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[11]
+	mi := &file_spec_proto_tun_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -776,7 +839,7 @@ func (x *PublishTunnelResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishTunnelResponse.ProtoReflect.Descriptor instead.
 func (*PublishTunnelResponse) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{11}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{12}
 }
 
 type Link struct {
@@ -791,7 +854,7 @@ type Link struct {
 func (x *Link) Reset() {
 	*x = Link{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[12]
+		mi := &file_spec_proto_tun_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -804,7 +867,7 @@ func (x *Link) String() string {
 func (*Link) ProtoMessage() {}
 
 func (x *Link) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[12]
+	mi := &file_spec_proto_tun_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -817,7 +880,7 @@ func (x *Link) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Link.ProtoReflect.Descriptor instead.
 func (*Link) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{12}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Link) GetAlpn() Link_ALPN {
@@ -846,7 +909,7 @@ type IdentitiesPair struct {
 func (x *IdentitiesPair) Reset() {
 	*x = IdentitiesPair{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_spec_proto_tun_proto_msgTypes[13]
+		mi := &file_spec_proto_tun_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -859,7 +922,7 @@ func (x *IdentitiesPair) String() string {
 func (*IdentitiesPair) ProtoMessage() {}
 
 func (x *IdentitiesPair) ProtoReflect() protoreflect.Message {
-	mi := &file_spec_proto_tun_proto_msgTypes[13]
+	mi := &file_spec_proto_tun_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -872,7 +935,7 @@ func (x *IdentitiesPair) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentitiesPair.ProtoReflect.Descriptor instead.
 func (*IdentitiesPair) Descriptor() ([]byte, []int) {
-	return file_spec_proto_tun_proto_rawDescGZIP(), []int{13}
+	return file_spec_proto_tun_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *IdentitiesPair) GetChord() *Node {
@@ -950,7 +1013,7 @@ var file_spec_proto_tun_proto_rawDesc = []byte{
 	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e,
 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2e, 0x50, 0x75, 0x62, 0x6c, 0x69, 0x73, 0x68,
 	0x54, 0x75, 0x6e, 0x6e, 0x65, 0x6c, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x52, 0x0d, 0x74,
-	0x75, 0x6e, 0x6e, 0x65, 0x6c, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x22, 0xbb, 0x02, 0x0a,
+	0x75, 0x6e, 0x6e, 0x65, 0x6c, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x22, 0xfd, 0x02, 0x0a,
 	0x0e, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12,
 	0x4e, 0x0a, 0x10, 0x72, 0x65, 0x67, 0x69, 0x73, 0x74, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f,
 	0x6e, 0x73, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x22, 0x2e, 0x70, 0x72, 0x6f, 0x74,
@@ -970,7 +1033,16 @@ var file_spec_proto_tun_proto_rawDesc = []byte{
 	0x6e, 0x73, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1f, 0x2e, 0x70, 0x72, 0x6f, 0x74,
 	0x6f, 0x63, 0x6f, 0x6c, 0x2e, 0x50, 0x75, 0x62, 0x6c, 0x69, 0x73, 0x68, 0x54, 0x75, 0x6e, 0x6e,
 	0x65, 0x6c, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x52, 0x0e, 0x74, 0x75, 0x6e, 0x6e,
-	0x65, 0x6c, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x41, 0x0a, 0x17, 0x52, 0x65,
+	0x65, 0x6c, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x40, 0x0a, 0x0c, 0x70, 0x69,
+	0x6e, 0x67, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x1c, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2e, 0x43, 0x6c, 0x69, 0x65,
+	0x6e, 0x74, 0x50, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x52, 0x0c,
+	0x70, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x4c, 0x0a, 0x12,
+	0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x50, 0x69, 0x6e, 0x67, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
+	0x73, 0x65, 0x12, 0x22, 0x0a, 0x04, 0x6e, 0x6f, 0x64, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x0e, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2e, 0x4e, 0x6f, 0x64, 0x65,
+	0x52, 0x04, 0x6e, 0x6f, 0x64, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x61, 0x70, 0x65, 0x78, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x61, 0x70, 0x65, 0x78, 0x22, 0x41, 0x0a, 0x17, 0x52, 0x65,
 	0x67, 0x69, 0x73, 0x74, 0x65, 0x72, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x74, 0x79, 0x52, 0x65,
 	0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x26, 0x0a, 0x06, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x18,
 	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x0e, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c,
@@ -1047,7 +1119,7 @@ func file_spec_proto_tun_proto_rawDescGZIP() []byte {
 }
 
 var file_spec_proto_tun_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_spec_proto_tun_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_spec_proto_tun_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_spec_proto_tun_proto_goTypes = []interface{}{
 	(TunnelRPC)(0),                      // 0: protocol.TunnelRPC
 	(Link_ALPN)(0),                      // 1: protocol.Link.ALPN
@@ -1055,46 +1127,49 @@ var file_spec_proto_tun_proto_goTypes = []interface{}{
 	(*ClientToken)(nil),                 // 3: protocol.ClientToken
 	(*ClientRequest)(nil),               // 4: protocol.ClientRequest
 	(*ClientResponse)(nil),              // 5: protocol.ClientResponse
-	(*RegisterIdentityRequest)(nil),     // 6: protocol.RegisterIdentityRequest
-	(*RegisterIdentityResponse)(nil),    // 7: protocol.RegisterIdentityResponse
-	(*GetNodesRequest)(nil),             // 8: protocol.GetNodesRequest
-	(*GetNodesResponse)(nil),            // 9: protocol.GetNodesResponse
-	(*GenerateHostnameRequest)(nil),     // 10: protocol.GenerateHostnameRequest
-	(*GenerateHostnameResponse)(nil),    // 11: protocol.GenerateHostnameResponse
-	(*PublishTunnelRequest)(nil),        // 12: protocol.PublishTunnelRequest
-	(*PublishTunnelResponse)(nil),       // 13: protocol.PublishTunnelResponse
-	(*Link)(nil),                        // 14: protocol.Link
-	(*IdentitiesPair)(nil),              // 15: protocol.IdentitiesPair
-	(*Node)(nil),                        // 16: protocol.Node
-	(*descriptor.EnumValueOptions)(nil), // 17: google.protobuf.EnumValueOptions
+	(*ClientPingResponse)(nil),          // 6: protocol.ClientPingResponse
+	(*RegisterIdentityRequest)(nil),     // 7: protocol.RegisterIdentityRequest
+	(*RegisterIdentityResponse)(nil),    // 8: protocol.RegisterIdentityResponse
+	(*GetNodesRequest)(nil),             // 9: protocol.GetNodesRequest
+	(*GetNodesResponse)(nil),            // 10: protocol.GetNodesResponse
+	(*GenerateHostnameRequest)(nil),     // 11: protocol.GenerateHostnameRequest
+	(*GenerateHostnameResponse)(nil),    // 12: protocol.GenerateHostnameResponse
+	(*PublishTunnelRequest)(nil),        // 13: protocol.PublishTunnelRequest
+	(*PublishTunnelResponse)(nil),       // 14: protocol.PublishTunnelResponse
+	(*Link)(nil),                        // 15: protocol.Link
+	(*IdentitiesPair)(nil),              // 16: protocol.IdentitiesPair
+	(*Node)(nil),                        // 17: protocol.Node
+	(*descriptor.EnumValueOptions)(nil), // 18: google.protobuf.EnumValueOptions
 }
 var file_spec_proto_tun_proto_depIdxs = []int32{
-	16, // 0: protocol.Tunnel.client:type_name -> protocol.Node
-	16, // 1: protocol.Tunnel.chord:type_name -> protocol.Node
-	16, // 2: protocol.Tunnel.tun:type_name -> protocol.Node
+	17, // 0: protocol.Tunnel.client:type_name -> protocol.Node
+	17, // 1: protocol.Tunnel.chord:type_name -> protocol.Node
+	17, // 2: protocol.Tunnel.tun:type_name -> protocol.Node
 	3,  // 3: protocol.ClientRequest.token:type_name -> protocol.ClientToken
 	0,  // 4: protocol.ClientRequest.kind:type_name -> protocol.TunnelRPC
-	6,  // 5: protocol.ClientRequest.registerRequest:type_name -> protocol.RegisterIdentityRequest
-	8,  // 6: protocol.ClientRequest.nodesRequest:type_name -> protocol.GetNodesRequest
-	10, // 7: protocol.ClientRequest.hostnameRequest:type_name -> protocol.GenerateHostnameRequest
-	12, // 8: protocol.ClientRequest.tunnelRequest:type_name -> protocol.PublishTunnelRequest
-	7,  // 9: protocol.ClientResponse.registerResponse:type_name -> protocol.RegisterIdentityResponse
-	9,  // 10: protocol.ClientResponse.nodesResponse:type_name -> protocol.GetNodesResponse
-	11, // 11: protocol.ClientResponse.hostnameResponse:type_name -> protocol.GenerateHostnameResponse
-	13, // 12: protocol.ClientResponse.tunnelResponse:type_name -> protocol.PublishTunnelResponse
-	16, // 13: protocol.RegisterIdentityRequest.client:type_name -> protocol.Node
-	3,  // 14: protocol.RegisterIdentityResponse.token:type_name -> protocol.ClientToken
-	16, // 15: protocol.GetNodesResponse.nodes:type_name -> protocol.Node
-	16, // 16: protocol.PublishTunnelRequest.servers:type_name -> protocol.Node
-	1,  // 17: protocol.Link.alpn:type_name -> protocol.Link.ALPN
-	16, // 18: protocol.IdentitiesPair.chord:type_name -> protocol.Node
-	16, // 19: protocol.IdentitiesPair.tun:type_name -> protocol.Node
-	17, // 20: protocol.alpn_name:extendee -> google.protobuf.EnumValueOptions
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	20, // [20:21] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	7,  // 5: protocol.ClientRequest.registerRequest:type_name -> protocol.RegisterIdentityRequest
+	9,  // 6: protocol.ClientRequest.nodesRequest:type_name -> protocol.GetNodesRequest
+	11, // 7: protocol.ClientRequest.hostnameRequest:type_name -> protocol.GenerateHostnameRequest
+	13, // 8: protocol.ClientRequest.tunnelRequest:type_name -> protocol.PublishTunnelRequest
+	8,  // 9: protocol.ClientResponse.registerResponse:type_name -> protocol.RegisterIdentityResponse
+	10, // 10: protocol.ClientResponse.nodesResponse:type_name -> protocol.GetNodesResponse
+	12, // 11: protocol.ClientResponse.hostnameResponse:type_name -> protocol.GenerateHostnameResponse
+	14, // 12: protocol.ClientResponse.tunnelResponse:type_name -> protocol.PublishTunnelResponse
+	6,  // 13: protocol.ClientResponse.pingResponse:type_name -> protocol.ClientPingResponse
+	17, // 14: protocol.ClientPingResponse.node:type_name -> protocol.Node
+	17, // 15: protocol.RegisterIdentityRequest.client:type_name -> protocol.Node
+	3,  // 16: protocol.RegisterIdentityResponse.token:type_name -> protocol.ClientToken
+	17, // 17: protocol.GetNodesResponse.nodes:type_name -> protocol.Node
+	17, // 18: protocol.PublishTunnelRequest.servers:type_name -> protocol.Node
+	1,  // 19: protocol.Link.alpn:type_name -> protocol.Link.ALPN
+	17, // 20: protocol.IdentitiesPair.chord:type_name -> protocol.Node
+	17, // 21: protocol.IdentitiesPair.tun:type_name -> protocol.Node
+	18, // 22: protocol.alpn_name:extendee -> google.protobuf.EnumValueOptions
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	22, // [22:23] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_spec_proto_tun_proto_init() }
@@ -1153,7 +1228,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RegisterIdentityRequest); i {
+			switch v := v.(*ClientPingResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1165,7 +1240,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RegisterIdentityResponse); i {
+			switch v := v.(*RegisterIdentityRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1177,7 +1252,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetNodesRequest); i {
+			switch v := v.(*RegisterIdentityResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1189,7 +1264,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetNodesResponse); i {
+			switch v := v.(*GetNodesRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1201,7 +1276,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GenerateHostnameRequest); i {
+			switch v := v.(*GetNodesResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1213,7 +1288,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GenerateHostnameResponse); i {
+			switch v := v.(*GenerateHostnameRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1225,7 +1300,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PublishTunnelRequest); i {
+			switch v := v.(*GenerateHostnameResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1237,7 +1312,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*PublishTunnelResponse); i {
+			switch v := v.(*PublishTunnelRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1249,7 +1324,7 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Link); i {
+			switch v := v.(*PublishTunnelResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1261,6 +1336,18 @@ func file_spec_proto_tun_proto_init() {
 			}
 		}
 		file_spec_proto_tun_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Link); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_spec_proto_tun_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IdentitiesPair); i {
 			case 0:
 				return &v.state
@@ -1279,7 +1366,7 @@ func file_spec_proto_tun_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_spec_proto_tun_proto_rawDesc,
 			NumEnums:      2,
-			NumMessages:   14,
+			NumMessages:   15,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/spec/protocol/tun_vtproto.pb.go
+++ b/spec/protocol/tun_vtproto.pb.go
@@ -245,6 +245,16 @@ func (m *ClientResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.PingResponse != nil {
+		size, err := m.PingResponse.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x7a
+	}
 	if m.TunnelResponse != nil {
 		size, err := m.TunnelResponse.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -284,6 +294,56 @@ func (m *ClientResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i = encodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ClientPingResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ClientPingResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ClientPingResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Apex) > 0 {
+		i -= len(m.Apex)
+		copy(dAtA[i:], m.Apex)
+		i = encodeVarint(dAtA, i, uint64(len(m.Apex)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Node != nil {
+		size, err := m.Node.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -814,6 +874,30 @@ func (m *ClientResponse) SizeVT() (n int) {
 	}
 	if m.TunnelResponse != nil {
 		l = m.TunnelResponse.SizeVT()
+		n += 1 + l + sov(uint64(l))
+	}
+	if m.PingResponse != nil {
+		l = m.PingResponse.SizeVT()
+		n += 1 + l + sov(uint64(l))
+	}
+	if m.unknownFields != nil {
+		n += len(m.unknownFields)
+	}
+	return n
+}
+
+func (m *ClientPingResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Node != nil {
+		l = m.Node.SizeVT()
+		n += 1 + l + sov(uint64(l))
+	}
+	l = len(m.Apex)
+	if l > 0 {
 		n += 1 + l + sov(uint64(l))
 	}
 	if m.unknownFields != nil {
@@ -1687,6 +1771,161 @@ func (m *ClientResponse) UnmarshalVT(dAtA []byte) error {
 			if err := m.TunnelResponse.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PingResponse", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.PingResponse == nil {
+				m.PingResponse = &ClientPingResponse{}
+			}
+			if err := m.PingResponse.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ClientPingResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClientPingResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClientPingResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Node", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Node == nil {
+				m.Node = &Node{}
+			}
+			if err := m.Node.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Apex", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Apex = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/spec/transport/transport.go
+++ b/spec/transport/transport.go
@@ -31,9 +31,6 @@ type Transport interface {
 	ReceiveDatagram() <-chan *DatagramDelegate
 	SendDatagram(*protocol.Node, []byte) error
 
-	TransportEstablished() <-chan *protocol.Node
-	TransportDestroyed() <-chan *protocol.Node
-
 	Accept(ctx context.Context) error
 
 	Stop()

--- a/spec/tun/key.go
+++ b/spec/tun/key.go
@@ -1,32 +1,27 @@
 package tun
 
 import (
-	"strconv"
+	"fmt"
 
 	"kon.nect.sh/specter/spec/protocol"
 )
 
-func BundleKey(hostname string, num int) string {
-	key := "/tunnel/bundle/" + hostname + "/" + strconv.FormatInt(int64(num), 10)
-	return key
-}
-
 func IdentitiesChordKey(chord *protocol.Node) string {
-	key := "/identities/chord/" + chord.GetAddress() + "/" + strconv.FormatUint(chord.GetId(), 10)
-	return key
+	return fmt.Sprintf("/identities/chord/%s/%d", chord.GetAddress(), chord.GetId())
 }
 
 func IdentitiesTunKey(tun *protocol.Node) string {
-	key := "/identities/tunnel/" + tun.GetAddress() + "/" + strconv.FormatUint(tun.GetId(), 10)
-	return key
+	return fmt.Sprintf("/identities/tunnel/%s/%d", tun.GetAddress(), tun.GetId())
+}
+
+func RoutingKey(hostname string, num int) string {
+	return fmt.Sprintf("/tunnel/bundle/%s/%d", hostname, num)
 }
 
 func ClientTokenKey(token *protocol.ClientToken) string {
-	key := "/tunnel/client/token/" + string(token.GetToken())
-	return key
+	return fmt.Sprintf("/tunnel/client/token/%s", token.GetToken())
 }
 
 func ClientHostnamesPrefix(token *protocol.ClientToken) string {
-	key := "/tunnel/client/hostnames/" + string(token.GetToken())
-	return key
+	return fmt.Sprintf("/tunnel/client/hostnames/%s", token.GetToken())
 }

--- a/tun/client/config.go
+++ b/tun/client/config.go
@@ -5,9 +5,10 @@ import (
 	"net/url"
 	"os"
 
+	"kon.nect.sh/specter/spec/chord"
+
 	"github.com/zhangyunhao116/skipmap"
 	"gopkg.in/yaml.v3"
-	"kon.nect.sh/specter/spec/chord"
 )
 
 type Tunnel struct {

--- a/tun/server/server.go
+++ b/tun/server/server.go
@@ -135,9 +135,10 @@ func (s *Server) getConn(ctx context.Context, bundle *protocol.Tunnel) (net.Conn
 	}
 }
 
+// TODO: make this more intelligent.
 func (s *Server) Dial(ctx context.Context, link *protocol.Link) (net.Conn, error) {
 	for k := 1; k <= tun.NumRedundantLinks; k++ {
-		key := tun.BundleKey(link.GetHostname(), k)
+		key := tun.RoutingKey(link.GetHostname(), k)
 		val, err := s.chord.Get([]byte(key))
 		if err != nil {
 			s.logger.Error("key lookup error", zap.String("key", key), zap.Error(err))

--- a/tun/server/server_test.go
+++ b/tun/server/server_test.go
@@ -20,6 +20,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	testRootDomain = "hello.com"
+)
+
 func assertBytes(got []byte, exp ...[]byte) bool {
 	for _, b := range exp {
 		r := bytes.Compare(got, b)
@@ -38,16 +42,16 @@ func getFixture(as *require.Assertions) (*zap.Logger, *mocks.VNode, *mocks.Trans
 	cht := new(mocks.Transport)
 	clt := new(mocks.Transport)
 
-	s := New(logger, n, clt, cht, "hello")
+	s := New(logger, n, clt, cht, testRootDomain)
 
 	return logger, n, clt, cht, s
 }
 
 func getExpected(link *protocol.Link) [][]byte {
 	return [][]byte{
-		[]byte(tun.BundleKey(link.GetHostname(), 1)),
-		[]byte(tun.BundleKey(link.GetHostname(), 2)),
-		[]byte(tun.BundleKey(link.GetHostname(), 3)),
+		[]byte(tun.RoutingKey(link.GetHostname(), 1)),
+		[]byte(tun.RoutingKey(link.GetHostname(), 2)),
+		[]byte(tun.RoutingKey(link.GetHostname(), 3)),
 	}
 }
 

--- a/util/acceptor/addr.go
+++ b/util/acceptor/addr.go
@@ -1,0 +1,18 @@
+package acceptor
+
+import "net"
+
+var emptyAddr = &nilAddr{}
+
+type nilAddr struct {
+}
+
+var _ net.Addr = (*nilAddr)(nil)
+
+func (nilAddr) Network() string {
+	return "nil"
+}
+
+func (nilAddr) String() string {
+	return "nil"
+}

--- a/util/acceptor/http2_acceptor.go
+++ b/util/acceptor/http2_acceptor.go
@@ -46,7 +46,7 @@ func (h *HTTP2Acceptor) Close() error {
 
 func (h *HTTP2Acceptor) Addr() net.Addr {
 	if h.parent == nil {
-		return nil
+		return emptyAddr
 	}
 	return h.parent.Addr()
 }

--- a/util/acceptor/http3_acceptor.go
+++ b/util/acceptor/http3_acceptor.go
@@ -50,7 +50,7 @@ func (h *HTTP3Acceptor) Close() error {
 
 func (h *HTTP3Acceptor) Addr() net.Addr {
 	if h.parent == nil {
-		return nil
+		return emptyAddr
 	}
 	return h.parent.Addr()
 }


### PR DESCRIPTION
tun client will now establish multiple connections to specter server and
automatically request more nodes to be connected to in order to maintain
at most 3 links.

tunnel will now live in its own command space

Other changes in this commit:
cmd/specter: move App definition to this package
spec/overlay: remove unused interfaces
integrations: attempting to create integration tests